### PR TITLE
Update LogManager.php for channels as subhandlers

### DIFF
--- a/LogManager.php
+++ b/LogManager.php
@@ -368,6 +368,21 @@ class LogManager implements LoggerInterface
             $config['handler_with'] ?? []
         );
 
+        if (array_key_exists('handler_channel', $with)) {
+            $channel = $this->get($with['handler_channel']);
+            if ($channel) {
+                if (! is_a($channel, Monolog::class)) {
+                    throw new InvalidArgumentException(
+                        'channel_handler '.$with['handler_channel'].' must be an instance of '.Monolog::class
+                    );
+                }
+                $handlers = $channel->getHandlers();
+                if (isset($handlers[0])) {
+                    $with['handler'] = $handlers[0];
+                }
+            }
+        }
+
         return new Monolog($this->parseChannel($config), [$this->prepareHandler(
             $this->app->make($config['handler'], $with), $config
         )]);


### PR DESCRIPTION
Make channels available as handler parameter for handlers that need or accept a subhandler.
i.e. \Monolog\Handler\BufferHandler

A possible coinfig could look like this:
return [
  'channels' => [
    'stack' => [
      'driver' => 'stack', ...
    ],
    'buffered' => [
      'driver' => 'monolog',
      'handler' => BufferHandler::class,
      'with' => [
        'handler_channel' => 'stack'
      ],
   ]
  ]
];